### PR TITLE
Non-busy loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "tinyio"
 readme = "README.md"
 requires-python = ">=3.11"
 urls = {repository = "https://github.com/patrick-kidger/tinyio"}
-version = "0.1.3"
+version = "0.1.4"
 
 [project.optional-dependencies]
 dev = ["pre-commit", "pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ src = []
 
 [tool.ruff.lint]
 fixable = ["I001", "F401", "UP"]
-ignore = ["E402", "E721", "E731", "E741", "F722"]
+ignore = ["E402", "E721", "E731", "E741", "F722", "UP038"]
 select = ["E", "F", "I001", "UP"]
 
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -19,6 +19,8 @@ def _test_done_callback():
     assert len(out) == 0
     event1.set()
     yield event3.wait()
+    for _ in range(20):
+        yield
     assert out == [2, 1]
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -190,16 +190,11 @@ def test_error_to_thread(exception_group):
         assert marker is True
         if exception_group is True:
             assert type(catcher.value) is BaseExceptionGroup
-            [raising, cancelled1, cancelled2] = catcher.value.exceptions
+            [raising, cancelled] = catcher.value.exceptions
             assert type(raising) is RuntimeError and str(raising) == "Raising!"
             assert _flat_tb(raising) == [workflow.__name__, "cancel", "cancel2"]
-            assert type(cancelled1) is tinyio.CancelledError
-            assert type(cancelled2) is tinyio.CancelledError
-            flat1 = _flat_tb(cancelled1)
-            flat2 = _flat_tb(cancelled2)
-            true_flat1 = ["target", "blocking_operation"]
-            true_flat2 = ["wait"]
-            assert (flat1 == true_flat1 and flat2 == true_flat2) or (flat1 == true_flat2 and flat2 == true_flat1)
+            assert type(cancelled) is tinyio.CancelledError
+            assert _flat_tb(cancelled) == ["target", "blocking_operation"]
         else:
             raising = catcher.value
             assert type(raising) is RuntimeError and str(raising) == "Raising!"
@@ -239,25 +234,19 @@ def test_error_to_thread_with_context(exception_group):
         assert type(runtime) is RuntimeError
         assert str(runtime) == "Kaboom"
         assert _flat_tb(runtime) == ["test_error_to_thread_with_context", "foo", "bar", "baz"]
-        return
-    elif exception_group is True:
-        assert type(catcher.value) is BaseExceptionGroup
-        runtime, value, cancelled = catcher.value.exceptions
-        assert type(cancelled) is tinyio.CancelledError
-        assert _flat_tb(cancelled) == ["wait"]
     else:
         assert type(catcher.value) is ExceptionGroup
         runtime, value = catcher.value.exceptions
-    assert type(runtime) is RuntimeError
-    assert str(runtime) == "Kaboom"
-    assert _flat_tb(runtime) == ["foo", "bar", "baz"]
-    assert type(value) is ValueError
-    assert str(value) == "Responding improperly to cancellation"
-    assert _flat_tb(value) == ["target", "blocking_operation"]
-    cancelled_context = value.__context__
-    assert cancelled_context is value.__cause__
-    assert type(cancelled_context) is tinyio.CancelledError
-    assert _flat_tb(cancelled_context) == ["blocking_operation", "sub_blocking_operation"]
+        assert type(runtime) is RuntimeError
+        assert str(runtime) == "Kaboom"
+        assert _flat_tb(runtime) == ["foo", "bar", "baz"]
+        assert type(value) is ValueError
+        assert str(value) == "Responding improperly to cancellation"
+        assert _flat_tb(value) == ["target", "blocking_operation"]
+        cancelled_context = value.__context__
+        assert cancelled_context is value.__cause__
+        assert type(cancelled_context) is tinyio.CancelledError
+        assert _flat_tb(cancelled_context) == ["blocking_operation", "sub_blocking_operation"]
 
 
 @pytest.mark.parametrize("exception_group", (None, False, True))

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -190,11 +190,16 @@ def test_error_to_thread(exception_group):
         assert marker is True
         if exception_group is True:
             assert type(catcher.value) is BaseExceptionGroup
-            [raising, cancelled] = catcher.value.exceptions
+            [raising, cancelled1, cancelled2] = catcher.value.exceptions
             assert type(raising) is RuntimeError and str(raising) == "Raising!"
-            assert type(cancelled) is tinyio.CancelledError
             assert _flat_tb(raising) == [workflow.__name__, "cancel", "cancel2"]
-            assert _flat_tb(cancelled) == ["target", "blocking_operation"]
+            assert type(cancelled1) is tinyio.CancelledError
+            assert type(cancelled2) is tinyio.CancelledError
+            flat1 = _flat_tb(cancelled1)
+            flat2 = _flat_tb(cancelled2)
+            true_flat1 = ["target", "blocking_operation"]
+            true_flat2 = ["wait"]
+            assert (flat1 == true_flat1 and flat2 == true_flat2) or (flat1 == true_flat2 and flat2 == true_flat1)
         else:
             raising = catcher.value
             assert type(raising) is RuntimeError and str(raising) == "Raising!"
@@ -234,19 +239,25 @@ def test_error_to_thread_with_context(exception_group):
         assert type(runtime) is RuntimeError
         assert str(runtime) == "Kaboom"
         assert _flat_tb(runtime) == ["test_error_to_thread_with_context", "foo", "bar", "baz"]
+        return
+    elif exception_group is True:
+        assert type(catcher.value) is BaseExceptionGroup
+        runtime, value, cancelled = catcher.value.exceptions
+        assert type(cancelled) is tinyio.CancelledError
+        assert _flat_tb(cancelled) == ["wait"]
     else:
         assert type(catcher.value) is ExceptionGroup
         runtime, value = catcher.value.exceptions
-        assert type(runtime) is RuntimeError
-        assert str(runtime) == "Kaboom"
-        assert _flat_tb(runtime) == ["foo", "bar", "baz"]
-        assert type(value) is ValueError
-        assert str(value) == "Responding improperly to cancellation"
-        assert _flat_tb(value) == ["target", "blocking_operation"]
-        cancelled = value.__context__
-        assert cancelled is value.__cause__
-        assert type(cancelled) is tinyio.CancelledError
-        assert _flat_tb(cancelled) == ["blocking_operation", "sub_blocking_operation"]
+    assert type(runtime) is RuntimeError
+    assert str(runtime) == "Kaboom"
+    assert _flat_tb(runtime) == ["foo", "bar", "baz"]
+    assert type(value) is ValueError
+    assert str(value) == "Responding improperly to cancellation"
+    assert _flat_tb(value) == ["target", "blocking_operation"]
+    cancelled_context = value.__context__
+    assert cancelled_context is value.__cause__
+    assert type(cancelled_context) is tinyio.CancelledError
+    assert _flat_tb(cancelled_context) == ["blocking_operation", "sub_blocking_operation"]
 
 
 @pytest.mark.parametrize("exception_group", (None, False, True))
@@ -264,7 +275,8 @@ def test_error_from_thread(exception_group):
         yield [baz(), tinyio.run_in_thread(blocking_operation)]
 
     def baz():
-        yield
+        while True:
+            yield
 
     loop = tinyio.Loop()
     with pytest.raises(BaseException) as catcher:
@@ -309,7 +321,8 @@ def test_error_from_thread_with_context(exception_group):
         yield [baz(), tinyio.run_in_thread(blocking_operation)]
 
     def baz():
-        yield
+        while True:
+            yield
 
     loop = tinyio.Loop()
     with pytest.raises(BaseException) as catcher:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -166,7 +166,7 @@ def test_event_double_wait(is_set: bool):
         yield wait
 
     loop = tinyio.Loop()
-    with pytest.raises(RuntimeError, match=re.escape("Do not yield `event.wait()` multiple times")):
+    with pytest.raises(RuntimeError, match=re.escape("Do not yield the same `event.wait()` multiple times")):
         loop.run(foo())
 
 

--- a/tinyio/__init__.py
+++ b/tinyio/__init__.py
@@ -2,8 +2,9 @@ from ._background import AsCompleted as AsCompleted, add_done_callback as add_do
 from ._core import (
     CancelledError as CancelledError,
     Coro as Coro,
+    Event as Event,
     Loop as Loop,
 )
-from ._sync import Barrier as Barrier, Event as Event, Lock as Lock, Semaphore as Semaphore
+from ._sync import Barrier as Barrier, Lock as Lock, Semaphore as Semaphore
 from ._thread import ThreadPool as ThreadPool, run_in_thread as run_in_thread
 from ._time import TimeoutError as TimeoutError, sleep as sleep, timeout as timeout

--- a/tinyio/_core.py
+++ b/tinyio/_core.py
@@ -49,6 +49,8 @@ class Loop:
 
         The final `return` from `coro`.
         """
+        if not isinstance(coro, Generator):
+            raise ValueError("Invalid input `coro`, which is not a coroutine (a function using `yield` statements).")
         queue: co.deque[_Todo] = co.deque()
         waiting_on: dict[Coro, list[Coro]] = {}
         waiting_for: dict[Coro, _WaitingFor] = {}

--- a/tinyio/_thread.py
+++ b/tinyio/_thread.py
@@ -3,8 +3,8 @@ import threading
 from collections.abc import Callable, Iterable
 from typing import ParamSpec, TypeVar, cast
 
-from ._core import CancelledError, Coro
-from ._sync import Event, Semaphore
+from ._core import CancelledError, Coro, Event
+from ._sync import Semaphore
 
 
 _T = TypeVar("_T")


### PR DESCRIPTION
Okay, this is a major refactor of the internals of the loop. It should no longer busy-poll for whether threads or sleeps have completed.

This is accomplished by (a) promoting `tinyio.Event.wait` from a regular coroutine to instead be special-cased by the event loop, (b) having `tinyio.Event.set` notifying a `threading.Event` that the loop can unblock, and (c) rewriting our various `while cond_not_satisfied: yield` operations into a `yield some_event.wait()` instead.

The extra complexity this implies means that we're now at 262 LOC for the core event loop (`pygount _core.py`). This is just about acceptable for our '~200 LOC' claim. Let's see if we need anything more in the future! 😁 